### PR TITLE
Renaming `distributionId` -> `id`

### DIFF
--- a/src/UniversalRewardsDistributor.sol
+++ b/src/UniversalRewardsDistributor.sol
@@ -16,7 +16,7 @@ import {ERC20} from "@solmate/tokens/ERC20.sol";
 contract UniversalRewardsDistributor is IUniversalRewardsDistributor {
     using SafeTransferLib for ERC20;
 
-    uint256 public nextDistributionId = 1;
+    uint256 public nextId = 1;
 
     /// @notice The merkle tree's roots of a given distribution.
     mapping(uint256 => bytes32) public rootOf;
@@ -50,209 +50,191 @@ contract UniversalRewardsDistributor is IUniversalRewardsDistributor {
     /// @dev A frozen distribution cannot be claimed by users.
     mapping(uint256 => bool) public isFrozen;
 
-    modifier onlyUpdater(uint256 distributionId) {
+    modifier onlyUpdater(uint256 id) {
         require(
-            isUpdaterOf[distributionId][msg.sender] || msg.sender == ownerOf[distributionId],
+            isUpdaterOf[id][msg.sender] || msg.sender == ownerOf[id],
             "UniversalRewardsDistributor: caller is not the updater"
         );
         _;
     }
 
-    modifier onlyTreasury(uint256 distributionId) {
-        require(msg.sender == treasuryOf[distributionId], "UniversalRewardsDistributor: caller is not the treasury");
+    modifier onlyTreasury(uint256 id) {
+        require(msg.sender == treasuryOf[id], "UniversalRewardsDistributor: caller is not the treasury");
         _;
     }
 
-    modifier onlyOwner(uint256 distributionId) {
-        require(msg.sender == ownerOf[distributionId], "UniversalRewardsDistributor: caller is not the owner");
+    modifier onlyOwner(uint256 id) {
+        require(msg.sender == ownerOf[id], "UniversalRewardsDistributor: caller is not the owner");
         _;
     }
 
-    modifier notFrozen(uint256 distributionId) {
-        require(!isFrozen[distributionId], "UniversalRewardsDistributor: frozen");
+    modifier notFrozen(uint256 id) {
+        require(!isFrozen[id], "UniversalRewardsDistributor: frozen");
         _;
     }
 
     /* EXTERNAL */
 
     /// @notice Proposes a new merkle tree root.
-    /// @param distributionId The distributionId of the merkle tree distribution.
+    /// @param id The id of the merkle tree distribution.
     /// @param newRoot The new merkle tree's root.
-    function proposeRoot(uint256 distributionId, bytes32 newRoot)
-        external
-        onlyUpdater(distributionId)
-        notFrozen(distributionId)
-    {
-        if (timelockOf[distributionId] == 0) {
-            rootOf[distributionId] = newRoot;
-            delete pendingRootOf[distributionId];
-            emit RootUpdated(distributionId, newRoot);
+    function proposeRoot(uint256 id, bytes32 newRoot) external onlyUpdater(id) notFrozen(id) {
+        if (timelockOf[id] == 0) {
+            rootOf[id] = newRoot;
+            delete pendingRootOf[id];
+            emit RootUpdated(id, newRoot);
         } else {
-            pendingRootOf[distributionId] = PendingRoot(block.timestamp, newRoot);
-            emit RootProposed(distributionId, newRoot);
+            pendingRootOf[id] = PendingRoot(block.timestamp, newRoot);
+            emit RootProposed(id, newRoot);
         }
     }
 
     /// @notice Accepts the current pending merkle tree's root.
-    /// @param distributionId The distributionId of the merkle tree distribution.
+    /// @param id The id of the merkle tree distribution.
     /// @dev This function can only be called after the timelock has expired.
     /// @dev Anyone can call this function.
-    function acceptRootUpdate(uint256 distributionId) external notFrozen(distributionId) {
-        PendingRoot memory pendingRoot = pendingRootOf[distributionId];
+    function acceptRootUpdate(uint256 id) external notFrozen(id) {
+        PendingRoot memory pendingRoot = pendingRootOf[id];
         require(pendingRoot.submittedAt > 0, "UniversalRewardsDistributor: no pending root");
         require(
-            block.timestamp >= pendingRoot.submittedAt + timelockOf[distributionId],
+            block.timestamp >= pendingRoot.submittedAt + timelockOf[id],
             "UniversalRewardsDistributor: timelock not expired"
         );
 
-        rootOf[distributionId] = pendingRoot.root;
-        delete pendingRootOf[distributionId];
+        rootOf[id] = pendingRoot.root;
+        delete pendingRootOf[id];
 
-        emit RootUpdated(distributionId, pendingRoot.root);
+        emit RootUpdated(id, pendingRoot.root);
     }
 
     /// @notice Claims rewards.
-    /// @param distributionId The distributionId of the merkle tree distribution.
+    /// @param id The id of the merkle tree distribution.
     /// @param account The address to claim rewards for.
     /// @param reward The address of the reward token.
     /// @param claimable The overall claimable amount of token rewards.
     /// @param proof The merkle proof that validates this claim.
-    function claim(uint256 distributionId, address account, address reward, uint256 claimable, bytes32[] calldata proof)
+    function claim(uint256 id, address account, address reward, uint256 claimable, bytes32[] calldata proof)
         external
-        notFrozen(distributionId)
+        notFrozen(id)
     {
-        require(rootOf[distributionId] != bytes32(0), "UniversalRewardsDistributor: root is not set");
+        require(rootOf[id] != bytes32(0), "UniversalRewardsDistributor: root is not set");
         require(
             MerkleProof.verifyCalldata(
-                proof,
-                rootOf[distributionId],
-                keccak256(bytes.concat(keccak256(abi.encode(account, reward, claimable))))
+                proof, rootOf[id], keccak256(bytes.concat(keccak256(abi.encode(account, reward, claimable))))
             ),
             "UniversalRewardsDistributor: invalid proof or expired"
         );
 
-        uint256 amount = claimable - claimed[distributionId][account][reward];
+        uint256 amount = claimable - claimed[id][account][reward];
 
         require(amount > 0, "UniversalRewardsDistributor: already claimed");
 
-        claimed[distributionId][account][reward] = claimable;
+        claimed[id][account][reward] = claimable;
 
-        ERC20(reward).safeTransferFrom(treasuryOf[distributionId], account, amount);
+        ERC20(reward).safeTransferFrom(treasuryOf[id], account, amount);
 
-        emit RewardsClaimed(distributionId, account, reward, amount);
+        emit RewardsClaimed(id, account, reward, amount);
     }
 
     /// @notice Creates a new distribution.
     /// @param initialTimelock The initial timelock for the new distribution.
     /// @param initialRoot The initial merkle tree's root for the new distribution.
     /// @dev The caller of this function is the owner and the treasury of the new distribution.
-    function createDistribution(uint256 initialTimelock, bytes32 initialRoot)
-        external
-        returns (uint256 distributionId)
-    {
-        distributionId = nextDistributionId++;
-        ownerOf[distributionId] = msg.sender;
-        treasuryOf[distributionId] = msg.sender;
-        timelockOf[distributionId] = initialTimelock;
+    function createDistribution(uint256 initialTimelock, bytes32 initialRoot) external returns (uint256 id) {
+        id = nextId++;
+        ownerOf[id] = msg.sender;
+        treasuryOf[id] = msg.sender;
+        timelockOf[id] = initialTimelock;
 
-        emit DistributionCreated(distributionId, msg.sender, initialTimelock);
+        emit DistributionCreated(id, msg.sender, initialTimelock);
 
         if (initialRoot != bytes32(0)) {
-            rootOf[distributionId] = initialRoot;
-            emit RootUpdated(distributionId, initialRoot);
+            rootOf[id] = initialRoot;
+            emit RootUpdated(id, initialRoot);
         }
     }
 
     /// @notice Proposes a new treasury address for a given distribution.
-    /// @param distributionId The distributionId of the merkle tree distribution.
+    /// @param id The id of the merkle tree distribution.
     /// @param newTreasury The new treasury address.
-    function proposeTreasury(uint256 distributionId, address newTreasury) external onlyOwner(distributionId) {
-        pendingTreasuryOf[distributionId] = newTreasury;
-        emit TreasuryProposed(distributionId, newTreasury);
+    function proposeTreasury(uint256 id, address newTreasury) external onlyOwner(id) {
+        pendingTreasuryOf[id] = newTreasury;
+        emit TreasuryProposed(id, newTreasury);
     }
 
     /// @notice Accepts the treasury role for a given distribution.
-    /// @param distributionId The distributionId of the merkle tree distribution.
-    function acceptAsTreasury(uint256 distributionId) external {
-        require(
-            msg.sender == pendingTreasuryOf[distributionId],
-            "UniversalRewardsDistributor: caller is not the pending treasury"
-        );
+    /// @param id The id of the merkle tree distribution.
+    function acceptAsTreasury(uint256 id) external {
+        require(msg.sender == pendingTreasuryOf[id], "UniversalRewardsDistributor: caller is not the pending treasury");
 
-        treasuryOf[distributionId] = msg.sender;
-        delete pendingTreasuryOf[distributionId];
+        treasuryOf[id] = msg.sender;
+        delete pendingTreasuryOf[id];
 
-        emit TreasuryUpdated(distributionId, msg.sender);
+        emit TreasuryUpdated(id, msg.sender);
     }
 
     /// @notice Freezes a given distribution.
-    /// @param distributionId The distributionId of the merkle tree distribution.
+    /// @param id The id of the merkle tree distribution.
     /// @param newIsFrozen Whether the distribution should be frozen or not.
-    function freeze(uint256 distributionId, bool newIsFrozen) external onlyOwner(distributionId) {
-        isFrozen[distributionId] = newIsFrozen;
-        emit Frozen(distributionId, newIsFrozen);
+    function freeze(uint256 id, bool newIsFrozen) external onlyOwner(id) {
+        isFrozen[id] = newIsFrozen;
+        emit Frozen(id, newIsFrozen);
     }
 
     /// @notice Forces update the root of a given distribution.
-    /// @param distributionId The distributionId of the merkle tree distribution.
+    /// @param id The id of the merkle tree distribution.
     /// @param newRoot The new merkle tree's root.
     /// @dev This function can only be called by the owner of the distribution.
     /// @dev The distribution must be frozen before.
-    function forceUpdateRoot(uint256 distributionId, bytes32 newRoot) external onlyOwner(distributionId) {
-        require(isFrozen[distributionId], "UniversalRewardsDistributor: not frozen");
-        rootOf[distributionId] = newRoot;
-        emit RootUpdated(distributionId, newRoot);
+    function forceUpdateRoot(uint256 id, bytes32 newRoot) external onlyOwner(id) {
+        require(isFrozen[id], "UniversalRewardsDistributor: not frozen");
+        rootOf[id] = newRoot;
+        emit RootUpdated(id, newRoot);
     }
 
     /// @notice Updates the timelock of a given distribution.
-    /// @param distributionId The distributionId of the merkle tree distribution.
+    /// @param id The id of the merkle tree distribution.
     /// @param newTimelock The new timelock.
     /// @dev This function can only be called by the owner of the distribution.
     /// @dev If the timelock is reduced, it can only be updated after the timelock has expired.
-    function updateTimelock(uint256 distributionId, uint256 newTimelock) external onlyOwner(distributionId) {
-        if (newTimelock < timelockOf[distributionId]) {
-            PendingRoot memory pendingRoot = pendingRootOf[distributionId];
+    function updateTimelock(uint256 id, uint256 newTimelock) external onlyOwner(id) {
+        if (newTimelock < timelockOf[id]) {
+            PendingRoot memory pendingRoot = pendingRootOf[id];
             require(
-                pendingRoot.submittedAt == 0 || pendingRoot.submittedAt + timelockOf[distributionId] <= block.timestamp,
+                pendingRoot.submittedAt == 0 || pendingRoot.submittedAt + timelockOf[id] <= block.timestamp,
                 "UniversalRewardsDistributor: timelock not expired"
             );
         }
 
-        timelockOf[distributionId] = newTimelock;
-        emit TimelockUpdated(distributionId, newTimelock);
+        timelockOf[id] = newTimelock;
+        emit TimelockUpdated(id, newTimelock);
     }
 
     /// @notice Updates the root updater of a given distribution.
-    /// @param distributionId The distributionId of the merkle tree distribution.
+    /// @param id The id of the merkle tree distribution.
     /// @param updater The new root updater.
     /// @param active Whether the root updater should be active or not.
-    function updateRootUpdater(uint256 distributionId, address updater, bool active)
-        external
-        onlyOwner(distributionId)
-    {
-        isUpdaterOf[distributionId][updater] = active;
-        emit RootUpdaterUpdated(distributionId, updater, active);
+    function updateRootUpdater(uint256 id, address updater, bool active) external onlyOwner(id) {
+        isUpdaterOf[id][updater] = active;
+        emit RootUpdaterUpdated(id, updater, active);
     }
 
     /// @notice Revokes the pending root of a given distribution.
-    /// @param distributionId The distributionId of the merkle tree distribution.
+    /// @param id The id of the merkle tree distribution.
     /// @dev This function can only be called by the owner of the distribution at any time.
-    function revokePendingRoot(uint256 distributionId) external onlyOwner(distributionId) {
-        require(pendingRootOf[distributionId].submittedAt != 0, "UniversalRewardsDistributor: no pending root");
+    function revokePendingRoot(uint256 id) external onlyOwner(id) {
+        require(pendingRootOf[id].submittedAt != 0, "UniversalRewardsDistributor: no pending root");
 
-        delete pendingRootOf[distributionId];
-        emit PendingRootRevoked(distributionId);
+        delete pendingRootOf[id];
+        emit PendingRootRevoked(id);
     }
 
-    function transferDistributionOwnership(uint256 distributionId, address newOwner)
-        external
-        onlyOwner(distributionId)
-    {
-        ownerOf[distributionId] = newOwner;
-        emit DistributionOwnershipTransferred(distributionId, msg.sender, newOwner);
+    function transferDistributionOwnership(uint256 id, address newOwner) external onlyOwner(id) {
+        ownerOf[id] = newOwner;
+        emit DistributionOwnershipTransferred(id, msg.sender, newOwner);
     }
 
-    function getPendingRoot(uint256 distributionId) external view returns (PendingRoot memory) {
-        return pendingRootOf[distributionId];
+    function getPendingRoot(uint256 id) external view returns (PendingRoot memory) {
+        return pendingRootOf[id];
     }
 }

--- a/src/interfaces/IUniversalRewardsDistributor.sol
+++ b/src/interfaces/IUniversalRewardsDistributor.sol
@@ -16,75 +16,69 @@ interface IUniversalRewardsDistributor {
     /* EVENTS */
 
     /// @notice Emitted when the merkle tree's root is updated.
-    /// @param distributionId The id of the merkle tree distribution.
+    /// @param id The id of the merkle tree distribution.
     /// @param newRoot The new merkle tree's root.
-    event RootUpdated(uint256 indexed distributionId, bytes32 newRoot);
+    event RootUpdated(uint256 indexed id, bytes32 newRoot);
 
     /// @notice Emitted when a new merkle tree's root is submitted.
     /// @param newRoot The new merkle tree's root.
-    event RootProposed(uint256 indexed distributionId, bytes32 newRoot);
+    event RootProposed(uint256 indexed id, bytes32 newRoot);
 
     /// @notice Emitted when a new Treasury.
-    /// @param distributionId The id of the merkle tree distribution.
+    /// @param id The id of the merkle tree distribution.
     /// @param newTreasury The new merkle tree's treasury where rewards are pulled from.
-    event TreasuryUpdated(uint256 indexed distributionId, address newTreasury);
+    event TreasuryUpdated(uint256 indexed id, address newTreasury);
 
     /// @notice Emitted when a new merkle tree's treasury is suggested by the owner.
-    /// @param distributionId The id of the merkle tree distribution.
+    /// @param id The id of the merkle tree distribution.
     /// @param newTreasury The new treasury that needs to approve the change.
-    event TreasuryProposed(uint256 indexed distributionId, address newTreasury);
+    event TreasuryProposed(uint256 indexed id, address newTreasury);
 
     /// @notice Emitted when a merkle tree is frozen or unfrozen by the owner.
-    /// @param distributionId The id of the merkle tree distribution.
+    /// @param id The id of the merkle tree distribution.
     /// @param frozen The new merkle tree's frozen state.
-    event Frozen(uint256 indexed distributionId, bool frozen);
+    event Frozen(uint256 indexed id, bool frozen);
 
     /// @notice Emitted when a merkle tree distribution timelock is modified.
-    /// @param distributionId The id of the merkle tree distribution.
+    /// @param id The id of the merkle tree distribution.
     /// @param timelock The new merkle tree's timelock.
-    event TimelockUpdated(uint256 indexed distributionId, uint256 timelock);
+    event TimelockUpdated(uint256 indexed id, uint256 timelock);
 
     /// @notice Emitted when a merkle tree distribution is created.
-    /// @param distributionId The id of the merkle tree distribution.
+    /// @param id The id of the merkle tree distribution.
     /// @param owner The owner of the merkle tree distribution.
     /// @param initialTimelock The initial timelock of the merkle tree distribution.
-    event DistributionCreated(uint256 indexed distributionId, address indexed owner, uint256 initialTimelock);
+    event DistributionCreated(uint256 indexed id, address indexed owner, uint256 initialTimelock);
 
     /// @notice Emitted when a merkle tree updater is added or removed.
-    /// @param distributionId The id of the merkle tree distribution.
+    /// @param id The id of the merkle tree distribution.
     /// @param rootUpdater The merkle tree updater.
     /// @param active The merkle tree updater's active state.
-    event RootUpdaterUpdated(uint256 indexed distributionId, address indexed rootUpdater, bool active);
+    event RootUpdaterUpdated(uint256 indexed id, address indexed rootUpdater, bool active);
 
     /// @notice Emitted when a merkle tree's pending root is revoked.
-    /// @param distributionId The id of the merkle tree distribution.
-    event PendingRootRevoked(uint256 indexed distributionId);
+    /// @param id The id of the merkle tree distribution.
+    event PendingRootRevoked(uint256 indexed id);
 
     /// @notice Emitted when rewards are claimed.
-    /// @param distributionId The id of the merkle tree distribution.
+    /// @param id The id of the merkle tree distribution.
     /// @param account The address for which rewards are claimd rewards for.
     /// @param reward The address of the reward token.
     /// @param amount The amount of reward token claimed.
-    event RewardsClaimed(
-        uint256 indexed distributionId, address indexed account, address indexed reward, uint256 amount
-    );
+    event RewardsClaimed(uint256 indexed id, address indexed account, address indexed reward, uint256 amount);
 
     /// @notice Emitted when the ownership of a merkle tree distribution is transferred.
-    /// @param distributionId The id of the merkle tree distribution.
+    /// @param id The id of the merkle tree distribution.
     /// @param previousOwner The previous owner of the merkle tree distribution.
     /// @param newOwner The new owner of the merkle tree distribution.
-    event DistributionOwnershipTransferred(
-        uint256 indexed distributionId, address indexed previousOwner, address indexed newOwner
-    );
+    event DistributionOwnershipTransferred(uint256 indexed id, address indexed previousOwner, address indexed newOwner);
 
     /* EXTERNAL */
 
     function proposeRoot(uint256 id, bytes32 newRoot) external;
     function acceptRootUpdate(uint256 id) external;
     function claim(uint256 id, address account, address reward, uint256 claimable, bytes32[] calldata proof) external;
-    function createDistribution(uint256 initialTimelock, bytes32 initialRoot)
-        external
-        returns (uint256 distributionId);
+    function createDistribution(uint256 initialTimelock, bytes32 initialRoot) external returns (uint256 id);
     function proposeTreasury(uint256 id, address newTreasury) external;
     function acceptAsTreasury(uint256 id) external;
     function freeze(uint256 id, bool isFrozen) external;


### PR DESCRIPTION
Fixes #3.

Because it's in the context of distributions I think it makes the code less verbose while still being clear. It removes some lines of code btw.