### PR TITLE
Feat/batch suggestions

### DIFF
--- a/src/UniversalRewardsDistributor.sol
+++ b/src/UniversalRewardsDistributor.sol
@@ -232,10 +232,6 @@ contract UniversalRewardsDistributor is IUniversalRewardsDistributor {
         emit DistributionOwnershipTransferred(distributionId, msg.sender, newOwner);
     }
 
-    function getPendingRoot(uint256 distributionId) external view returns (PendingRoot memory) {
-        return pendingRootOf[distributionId];
-    }
-
     function _forceUpdateRoot(uint256 distributionId, bytes32 newRoot) internal {
         rootOf[distributionId] = newRoot;
         delete pendingRootOf[distributionId];

--- a/src/UniversalRewardsDistributor.sol
+++ b/src/UniversalRewardsDistributor.sol
@@ -132,7 +132,7 @@ contract UniversalRewardsDistributor is IUniversalRewardsDistributor {
     /// @param initialRoot The initial merkle tree's root for the new distribution.
     /// @param initialOwner The initial owner for the new distribution.
     /// @param initialPendingTreasury The initial pending treasury for the new distribution.
-    /// @dev the initial treasury is always msg.sender. The initialPendingTreasury can be set to address(0).
+    /// @dev The initial treasury is always `msg.sender`. The `initialPendingTreasury` can be set to `address(0)`.
     function createDistribution(
         uint256 initialTimelock,
         bytes32 initialRoot,

--- a/src/interfaces/IUniversalRewardsDistributor.sol
+++ b/src/interfaces/IUniversalRewardsDistributor.sol
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.5.0;
 
+
+
+
 /// @title IUniversalRewardsDistributor
 /// @author Morpho Labs
 /// @notice UniversalRewardsDistributor's interface.
@@ -96,5 +99,9 @@ interface IUniversalRewardsDistributor {
     function updateTimelock(uint256 id, uint256 newTimelock) external;
     function updateRootUpdater(uint256 id, address updater, bool active) external;
     function revokePendingRoot(uint256 id) external;
-    function getPendingRoot(uint256 id) external view returns (PendingRoot memory);
+}
+
+
+interface IPendingRoot {
+    function pendingRootOf(uint256 distributionId) external view returns (IUniversalRewardsDistributor.PendingRoot memory);
 }

--- a/src/interfaces/IUniversalRewardsDistributor.sol
+++ b/src/interfaces/IUniversalRewardsDistributor.sol
@@ -48,7 +48,9 @@ interface IUniversalRewardsDistributor {
     /// @param distributionId The id of the merkle tree distribution.
     /// @param owner The owner of the merkle tree distribution.
     /// @param initialTimelock The initial timelock of the merkle tree distribution.
-    event DistributionCreated(uint256 indexed distributionId, address indexed owner, uint256 initialTimelock);
+    event DistributionCreated(
+        uint256 indexed distributionId, address indexed caller, address indexed owner, uint256 initialTimelock
+    );
 
     /// @notice Emitted when a merkle tree updater is added or removed.
     /// @param distributionId The id of the merkle tree distribution.
@@ -82,12 +84,14 @@ interface IUniversalRewardsDistributor {
     function proposeRoot(uint256 id, bytes32 newRoot) external;
     function acceptRootUpdate(uint256 id) external;
     function claim(uint256 id, address account, address reward, uint256 claimable, bytes32[] calldata proof) external;
-    function createDistribution(uint256 initialTimelock, bytes32 initialRoot)
-        external
-        returns (uint256 distributionId);
+    function createDistribution(
+        uint256 initialTimelock,
+        bytes32 initialRoot,
+        address initialOwner,
+        address initialPendingTreasury
+    ) external returns (uint256 distributionId);
     function proposeTreasury(uint256 id, address newTreasury) external;
     function acceptAsTreasury(uint256 id) external;
-    function freeze(uint256 id, bool isFrozen) external;
     function forceUpdateRoot(uint256 id, bytes32 newRoot) external;
     function updateTimelock(uint256 id, uint256 newTimelock) external;
     function updateRootUpdater(uint256 id, address updater, bool active) external;

--- a/src/interfaces/IUniversalRewardsDistributor.sol
+++ b/src/interfaces/IUniversalRewardsDistributor.sol
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.5.0;
 
-
-
-
 /// @title IUniversalRewardsDistributor
 /// @author Morpho Labs
 /// @notice UniversalRewardsDistributor's interface.

--- a/src/libraries/ErrorsLib.sol
+++ b/src/libraries/ErrorsLib.sol
@@ -13,8 +13,6 @@ library ErrorsLib {
 
     string internal constant CALLER_NOT_OWNER = "UniversalRewardsDistributor: caller is not the owner";
 
-    string internal constant FROZEN = "UniversalRewardsDistributor: frozen";
-
     string internal constant NO_PENDING_ROOT = "UniversalRewardsDistributor: no pending root";
 
     string internal constant TIMELOCK_NOT_EXPIRED = "UniversalRewardsDistributor: timelock is not expired";
@@ -27,6 +25,4 @@ library ErrorsLib {
 
     string internal constant CALLER_NOT_PENDING_TREASURY =
         "UniversalRewardsDistributor: caller is not the pending treasury";
-
-    string internal constant NOT_FROZEN = "UniversalRewardsDistributor: not frozen";
 }

--- a/test/UniversalRouterDistributor.t.sol
+++ b/test/UniversalRouterDistributor.t.sol
@@ -32,9 +32,10 @@ contract UniversalRouterDistributor is Test {
     event RootProposed(uint256 indexed distributionId, bytes32 newRoot);
     event TreasuryUpdated(uint256 indexed distributionId, address newTreasury);
     event TreasuryProposed(uint256 indexed distributionId, address newTreasury);
-    event Frozen(uint256 indexed distributionId, bool frozen);
     event TimelockUpdated(uint256 indexed distributionId, uint256 timelock);
-    event DistributionCreated(uint256 indexed distributionId, address indexed owner, uint256 initialTimelock);
+    event DistributionCreated(
+        uint256 indexed distributionId, address indexed caller, address indexed owner, uint256 initialTimelock
+    );
     event RootUpdaterUpdated(uint256 indexed distributionId, address indexed rootUpdater, bool active);
     event PendingRootRevoked(uint256 indexed distributionId);
     event RewardsClaimed(
@@ -50,13 +51,13 @@ contract UniversalRouterDistributor is Test {
         token2 = new MockERC20("Token2", "TKN2", 18);
 
         vm.prank(owner);
-        distributionWithoutTimeLock = distributor.createDistribution(0, bytes32(0));
+        distributionWithoutTimeLock = distributor.createDistribution(0, bytes32(0), address(0), address(0));
         vm.prank(owner);
         distributor.updateRootUpdater(distributionWithoutTimeLock, updater, true);
 
         vm.warp(block.timestamp + 1);
         vm.startPrank(owner);
-        distributionWithTimeLock = distributor.createDistribution(DEFAULT_TIMELOCK, bytes32(0));
+        distributionWithTimeLock = distributor.createDistribution(DEFAULT_TIMELOCK, bytes32(0), address(0), address(0));
         distributor.updateRootUpdater(distributionWithTimeLock, updater, true);
         vm.stopPrank();
 
@@ -74,10 +75,12 @@ contract UniversalRouterDistributor is Test {
 
         vm.prank(randomCreator);
         vm.expectEmit(true, true, true, true, address(distributor));
-        emit IUniversalRewardsDistributor.DistributionCreated(distributionId, randomCreator, DEFAULT_TIMELOCK);
+        emit IUniversalRewardsDistributor.DistributionCreated(
+            distributionId, randomCreator, randomCreator, DEFAULT_TIMELOCK
+        );
         vm.expectEmit(true, true, true, true, address(distributor));
         emit IUniversalRewardsDistributor.RootUpdated(distributionId, DEFAULT_ROOT);
-        distributor.createDistribution(DEFAULT_TIMELOCK, DEFAULT_ROOT);
+        distributor.createDistribution(DEFAULT_TIMELOCK, DEFAULT_ROOT, address(0), address(0));
 
         assertEq(distributor.rootOf(distributionId), DEFAULT_ROOT);
         assertEq(distributor.timelockOf(distributionId), DEFAULT_TIMELOCK);
@@ -87,8 +90,64 @@ contract UniversalRouterDistributor is Test {
         assertEq(distributor.ownerOf(distributionId), randomCreator);
         assertEq(distributor.treasuryOf(distributionId), randomCreator);
         assertEq(distributor.pendingTreasuryOf(distributionId), address(0));
-        assertEq(distributor.isFrozen(distributionId), false);
         assertEq(distributor.nextDistributionId(), distributionId + 1);
+    }
+
+    function testCreateDistributionWithNewOwnerProvided(address newOwner) public {
+        vm.assume(newOwner != address(0));
+
+        uint256 distributionId = distributor.nextDistributionId();
+
+        vm.prank(owner);
+        vm.expectEmit(true, true, true, true, address(distributor));
+        emit IUniversalRewardsDistributor.DistributionCreated(
+            distributionId, owner, newOwner, DEFAULT_TIMELOCK
+        );
+        distributionId = distributor.createDistribution(DEFAULT_TIMELOCK, DEFAULT_ROOT, newOwner, address(0));
+
+        assertEq(distributor.ownerOf(distributionId), newOwner);
+        assertEq(distributor.treasuryOf(distributionId), owner);
+    }
+
+    function testCreateDistributionWithNewPendingTreasuryProvided(address newPendingTreasury) public {
+        vm.assume(newPendingTreasury != address(0));
+
+        uint256 distributionId = distributor.nextDistributionId();
+        vm.prank(owner);
+        vm.expectEmit(true, true, true, true, address(distributor));
+        emit IUniversalRewardsDistributor.TreasuryProposed(distributionId, newPendingTreasury);
+        distributionId =
+            distributor.createDistribution(DEFAULT_TIMELOCK, DEFAULT_ROOT, address(0), newPendingTreasury);
+
+        assertEq(distributor.ownerOf(distributionId), owner);
+        assertEq(distributor.treasuryOf(distributionId), owner);
+        assertEq(distributor.pendingTreasuryOf(distributionId), newPendingTreasury);
+    }
+
+    function testCreateDistributionWithAnInitialRoot() public {
+
+        vm.prank(owner);
+        vm.expectEmit(true, true, true, true, address(distributor));
+        emit IUniversalRewardsDistributor.RootUpdated(distributor.nextDistributionId(), DEFAULT_ROOT);
+        uint256 distributionId =
+            distributor.createDistribution(DEFAULT_TIMELOCK, DEFAULT_ROOT, address(0), address(0));
+
+        assertEq(distributor.rootOf(distributionId), DEFAULT_ROOT);
+        assertEq(distributor.getPendingRoot(distributionId).root, bytes32(0));
+    }
+
+    function testNextDistributionIdShouldBeIncrementedAfterDistributionCreation(
+        uint256 timelock,
+        bytes32 initialRoot,
+        address newOwner,
+        address newPendingTreasury
+    ) public {
+        uint256 initialRootId = distributor.nextDistributionId();
+        vm.prank(owner);
+        uint256 distributionId = distributor.createDistribution(timelock, initialRoot, newOwner, newPendingTreasury);
+
+        assertEq(distributionId, initialRootId);
+        assertEq(distributor.nextDistributionId(), initialRootId + 1);
     }
 
     function testUpdateRootWithoutTimelockAsOwner() public {
@@ -161,25 +220,6 @@ contract UniversalRouterDistributor is Test {
         distributor.proposeRoot(distributionWithoutTimeLock, DEFAULT_ROOT);
     }
 
-    function testProposeRootShouldRevertIfFrozenAsOwner() public {
-        vm.startPrank(owner);
-        distributor.freeze(distributionWithoutTimeLock, true);
-
-        vm.expectRevert(bytes(ErrorsLib.FROZEN));
-        distributor.proposeRoot(distributionWithoutTimeLock, DEFAULT_ROOT);
-
-        vm.stopPrank();
-    }
-
-    function testProposeRootShouldRevertIfFrozenAsUpdater() public {
-        vm.prank(owner);
-        distributor.freeze(distributionWithoutTimeLock, true);
-
-        vm.prank(updater);
-        vm.expectRevert(bytes(ErrorsLib.FROZEN));
-        distributor.proposeRoot(distributionWithoutTimeLock, DEFAULT_ROOT);
-    }
-
     function testAcceptRootUpdateShouldUpdateMainRoot(address randomCaller) public {
         vm.prank(updater);
         distributor.proposeRoot(distributionWithTimeLock, DEFAULT_ROOT);
@@ -197,21 +237,6 @@ contract UniversalRouterDistributor is Test {
             distributor.getPendingRoot(distributionWithTimeLock);
         assertEq(pendingRoot.root, bytes32(0));
         assertEq(pendingRoot.submittedAt, 0);
-    }
-
-    function testAcceptRootUpdateShouldRevertIfFrozen(address randomCaller) public {
-        vm.prank(updater);
-        distributor.proposeRoot(distributionWithTimeLock, DEFAULT_ROOT);
-
-        assert(distributor.rootOf(distributionWithTimeLock) != DEFAULT_ROOT);
-
-        vm.prank(owner);
-        distributor.freeze(distributionWithTimeLock, true);
-        vm.warp(block.timestamp + 1 days);
-
-        vm.prank(randomCaller);
-        vm.expectRevert(bytes(ErrorsLib.FROZEN));
-        distributor.acceptRootUpdate(distributionWithTimeLock);
     }
 
     function testAcceptRootUpdateShouldRevertIfTimelockNotFinished(address randomCaller, uint256 timeElapsed) public {
@@ -280,51 +305,25 @@ contract UniversalRouterDistributor is Test {
         assertEq(distributor.treasuryOf(distributionWithoutTimeLock), owner);
     }
 
-    function testFreezeShouldFreezeTheDistribution(bool freeze) public {
-        vm.prank(owner);
-        vm.expectEmit(true, true, true, true, address(distributor));
-        emit IUniversalRewardsDistributor.Frozen(distributionWithoutTimeLock, freeze);
-        distributor.freeze(distributionWithoutTimeLock, freeze);
-
-        assertEq(distributor.isFrozen(distributionWithoutTimeLock), freeze);
-    }
-
-    function testFreezeShouldRevertIfNotOwner(address randomCaller, bool isFrozen) public {
-        vm.assume(randomCaller != owner);
-
-        vm.prank(randomCaller);
-        vm.expectRevert(bytes(ErrorsLib.CALLER_NOT_OWNER));
-        distributor.freeze(distributionWithoutTimeLock, isFrozen);
-    }
-
-    function testForceUpdateRootShouldForceNewRootWhenFrozen(bytes32 newRoot) public {
-        vm.startPrank(owner);
-        distributor.freeze(distributionWithoutTimeLock, true);
-
-        vm.expectEmit(true, true, true, true, address(distributor));
-        emit IUniversalRewardsDistributor.RootUpdated(distributionWithoutTimeLock, newRoot);
-        distributor.forceUpdateRoot(distributionWithoutTimeLock, newRoot);
-        vm.stopPrank();
-
-        assertEq(distributor.rootOf(distributionWithoutTimeLock), newRoot);
-        assertEq(distributor.isFrozen(distributionWithoutTimeLock), true);
-    }
-
     function testForceUpdateRootShouldRevertIfNotOwner(bytes32 newRoot, address randomCaller) public {
         vm.assume(newRoot != bytes32(0) && randomCaller != owner);
 
-        vm.prank(owner);
-        distributor.freeze(distributionWithoutTimeLock, true);
-
         vm.prank(randomCaller);
         vm.expectRevert(bytes(ErrorsLib.CALLER_NOT_OWNER));
         distributor.forceUpdateRoot(distributionWithoutTimeLock, newRoot);
     }
 
-    function testForceUpdateRootShouldRevertIfNotFrozen(bytes32 newRoot) public {
-        vm.prank(owner);
-        vm.expectRevert(bytes(ErrorsLib.NOT_FROZEN));
-        distributor.forceUpdateRoot(distributionWithoutTimeLock, newRoot);
+    function testForceUpdateRootShouldRemovePendingRoot(bytes32 newRoot, address randomCaller) public {
+        vm.assume(newRoot != DEFAULT_ROOT && randomCaller != owner);
+
+        vm.startPrank(owner);
+        distributor.proposeRoot(distributionWithTimeLock, DEFAULT_ROOT);
+
+        assertEq(distributor.getPendingRoot(distributionWithTimeLock).root, DEFAULT_ROOT);
+
+        distributor.forceUpdateRoot(distributionWithTimeLock, newRoot);
+        assertEq(distributor.getPendingRoot(distributionWithTimeLock).root, bytes32(0));
+        vm.stopPrank();
     }
 
     function testUpdateTimelockShouldChangeTheDistributionTimelock(uint256 newTimelock) public {
@@ -510,23 +509,6 @@ contract UniversalRouterDistributor is Test {
         distributor.claim(distributionWithoutTimeLock, vm.addr(1), address(token1), claimable, proof1);
 
         vm.expectRevert(bytes(ErrorsLib.ALREADY_CLAIMED));
-        distributor.claim(distributionWithoutTimeLock, vm.addr(1), address(token1), claimable, proof1);
-    }
-
-    function testClaimRewardsShouldRevertIfFrozen(uint256 claimable) public {
-        claimable = bound(claimable, 1 ether, 1000 ether);
-
-        (bytes32[] memory data, bytes32 root) = _setupRewards(claimable, 2);
-
-        vm.startPrank(owner);
-        distributor.proposeRoot(distributionWithoutTimeLock, root);
-        distributor.freeze(distributionWithoutTimeLock, true);
-        vm.stopPrank();
-
-        assertEq(distributor.rootOf(distributionWithoutTimeLock), root);
-        bytes32[] memory proof1 = merkle.getProof(data, 0);
-
-        vm.expectRevert(bytes(ErrorsLib.FROZEN));
         distributor.claim(distributionWithoutTimeLock, vm.addr(1), address(token1), claimable, proof1);
     }
 

--- a/test/UniversalRouterDistributor.t.sol
+++ b/test/UniversalRouterDistributor.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
 
-import {IUniversalRewardsDistributor} from "src/interfaces/IUniversalRewardsDistributor.sol";
+import {IUniversalRewardsDistributor, IPendingRoot} from "src/interfaces/IUniversalRewardsDistributor.sol";
 
 import {ErrorsLib} from "src/libraries/ErrorsLib.sol";
 
@@ -84,7 +84,7 @@ contract UniversalRouterDistributor is Test {
 
         assertEq(distributor.rootOf(distributionId), DEFAULT_ROOT);
         assertEq(distributor.timelockOf(distributionId), DEFAULT_TIMELOCK);
-        IUniversalRewardsDistributor.PendingRoot memory pendingRoot = distributor.getPendingRoot(distributionId);
+        IUniversalRewardsDistributor.PendingRoot memory pendingRoot = _getPendingRoot(distributionId);
         assertEq(pendingRoot.root, bytes32(0));
         assertEq(pendingRoot.submittedAt, 0);
         assertEq(distributor.ownerOf(distributionId), randomCreator);
@@ -133,7 +133,7 @@ contract UniversalRouterDistributor is Test {
             distributor.createDistribution(DEFAULT_TIMELOCK, DEFAULT_ROOT, address(0), address(0));
 
         assertEq(distributor.rootOf(distributionId), DEFAULT_ROOT);
-        assertEq(distributor.getPendingRoot(distributionId).root, bytes32(0));
+        assertEq(_getPendingRoot(distributionId).root, bytes32(0));
     }
 
     function testNextDistributionIdShouldBeIncrementedAfterDistributionCreation(
@@ -158,7 +158,7 @@ contract UniversalRouterDistributor is Test {
 
         assertEq(distributor.rootOf(distributionWithoutTimeLock), DEFAULT_ROOT);
         IUniversalRewardsDistributor.PendingRoot memory pendingRoot =
-            distributor.getPendingRoot(distributionWithoutTimeLock);
+            _getPendingRoot(distributionWithoutTimeLock);
         assertEq(pendingRoot.root, bytes32(0));
         assertEq(pendingRoot.submittedAt, 0);
     }
@@ -171,7 +171,7 @@ contract UniversalRouterDistributor is Test {
 
         assertEq(distributor.rootOf(distributionWithoutTimeLock), DEFAULT_ROOT);
         IUniversalRewardsDistributor.PendingRoot memory pendingRoot =
-            distributor.getPendingRoot(distributionWithoutTimeLock);
+            _getPendingRoot(distributionWithoutTimeLock);
         assertEq(pendingRoot.root, bytes32(0));
         assertEq(pendingRoot.submittedAt, 0);
     }
@@ -193,7 +193,7 @@ contract UniversalRouterDistributor is Test {
         assert(distributor.rootOf(distributionWithTimeLock) != DEFAULT_ROOT);
 
         IUniversalRewardsDistributor.PendingRoot memory pendingRoot =
-            distributor.getPendingRoot(distributionWithTimeLock);
+            _getPendingRoot(distributionWithTimeLock);
         assertEq(pendingRoot.root, DEFAULT_ROOT);
         assertEq(pendingRoot.submittedAt, block.timestamp);
     }
@@ -207,7 +207,7 @@ contract UniversalRouterDistributor is Test {
         assert(distributor.rootOf(distributionWithTimeLock) != DEFAULT_ROOT);
 
         IUniversalRewardsDistributor.PendingRoot memory pendingRoot =
-            distributor.getPendingRoot(distributionWithTimeLock);
+            _getPendingRoot(distributionWithTimeLock);
         assertEq(pendingRoot.root, DEFAULT_ROOT);
         assertEq(pendingRoot.submittedAt, block.timestamp);
     }
@@ -234,7 +234,7 @@ contract UniversalRouterDistributor is Test {
 
         assertEq(distributor.rootOf(distributionWithTimeLock), DEFAULT_ROOT);
         IUniversalRewardsDistributor.PendingRoot memory pendingRoot =
-            distributor.getPendingRoot(distributionWithTimeLock);
+            _getPendingRoot(distributionWithTimeLock);
         assertEq(pendingRoot.root, bytes32(0));
         assertEq(pendingRoot.submittedAt, 0);
     }
@@ -319,10 +319,10 @@ contract UniversalRouterDistributor is Test {
         vm.startPrank(owner);
         distributor.proposeRoot(distributionWithTimeLock, DEFAULT_ROOT);
 
-        assertEq(distributor.getPendingRoot(distributionWithTimeLock).root, DEFAULT_ROOT);
+        assertEq(_getPendingRoot(distributionWithTimeLock).root, DEFAULT_ROOT);
 
         distributor.forceUpdateRoot(distributionWithTimeLock, newRoot);
-        assertEq(distributor.getPendingRoot(distributionWithTimeLock).root, bytes32(0));
+        assertEq(_getPendingRoot(distributionWithTimeLock).root, bytes32(0));
         vm.stopPrank();
     }
 
@@ -436,7 +436,7 @@ contract UniversalRouterDistributor is Test {
         distributor.revokePendingRoot(distributionWithTimeLock);
 
         IUniversalRewardsDistributor.PendingRoot memory pendingRoot =
-            distributor.getPendingRoot(distributionWithTimeLock);
+            _getPendingRoot(distributionWithTimeLock);
         assertEq(pendingRoot.root, bytes32(0));
         assertEq(pendingRoot.submittedAt, 0);
     }
@@ -631,5 +631,9 @@ contract UniversalRouterDistributor is Test {
 
     function _addrFromHashedString(string memory str) internal pure returns (address) {
         return address(uint160(uint256(keccak256(bytes(str)))));
+    }
+
+    function _getPendingRoot(uint256 distributionId) internal view returns (IUniversalRewardsDistributor.PendingRoot memory) {
+        return IPendingRoot(address(distributor)).pendingRootOf(distributionId);
     }
 }


### PR DESCRIPTION
## Changes provided
- `forceUpdateRoot` is now cleaning `PendingRoot`

Fixes: #24 

- `createDistribution` accepts more customization in one initial call (such as newOwner or pendingTreasury)
> **warning**
> The caller is always the initial treasury, for security reason.

Fixes: #22 

- Use an empty root for the frozen state.
> **warning**
> It changes the specs of the frozen state: if a root is settled to `bytes32(0)`, a `rootSubmitter` can always propose a new root, and this new root can still be accepted after the timelock. 

A consequence of removing this frozen state is that it is no longer checked in `forceRootUpdate`

Fixes: #6
Fixes: #14

- Remove `getPendingRoot` redundant function 

Fixes: #21 