### PR TITLE
docs(urd): rename things

### DIFF
--- a/src/UniversalRewardsDistributor.sol
+++ b/src/UniversalRewardsDistributor.sol
@@ -20,19 +20,19 @@ contract UniversalRewardsDistributor is IUniversalRewardsDistributor {
 
     /* STORAGE */
 
-    /// @notice The merkle tree's root of a given distribution.
+    /// @notice The merkle root of this distribution.
     bytes32 public root;
 
     /// @notice The optional ipfs hash containing metadata about the root (e.g. the merkle tree itself).
     bytes32 public ipfsHash;
 
-    /// @notice The `amount` of `reward` token already claimed by `account` for one given distribution.
+    /// @notice The `amount` of `reward` token already claimed by `account`.
     mapping(address account => mapping(address reward => uint256 amount)) public claimed;
 
     /// @notice The address that can update the distribution parameters, and freeze a root.
     address public owner;
 
-    /// @notice The addresses that can update the merkle tree's root for a given distribution.
+    /// @notice The addresses that can update the merkle root.
     mapping(address => bool) public isUpdater;
 
     /// @notice The timelock before a root update.
@@ -62,7 +62,7 @@ contract UniversalRewardsDistributor is IUniversalRewardsDistributor {
     /// @notice Initializes the contract.
     /// @param initialOwner The initial owner of the contract.
     /// @param initialTimelock The initial timelock of the contract.
-    /// @param initialRoot The initial merkle tree's root.
+    /// @param initialRoot The initial merkle root.
     /// @param initialIpfsHash The optional ipfs hash containing metadata about the root (e.g. the merkle tree itself).
     /// @dev Warning: The `initialIpfsHash` might not correspond to the `initialRoot`.
     constructor(address initialOwner, uint256 initialTimelock, bytes32 initialRoot, bytes32 initialIpfsHash) {
@@ -75,11 +75,11 @@ contract UniversalRewardsDistributor is IUniversalRewardsDistributor {
 
     /* EXTERNAL */
 
-    /// @notice Proposes a new merkle tree root.
-    /// @param newRoot The new merkle tree's root.
+    /// @notice Submits a new merkle root.
+    /// @param newRoot The new merkle root.
     /// @param newIpfsHash The optional ipfs hash containing metadata about the root (e.g. the merkle tree itself).
     /// @dev Warning: The `newIpfsHash` might not correspond to the `newRoot`.
-    function proposeRoot(bytes32 newRoot, bytes32 newIpfsHash) external onlyOwnerOrUpdater {
+    function submitRoot(bytes32 newRoot, bytes32 newIpfsHash) external onlyOwnerOrUpdater {
         if (timelock == 0) {
             _setRoot(newRoot, newIpfsHash);
         } else {
@@ -88,7 +88,7 @@ contract UniversalRewardsDistributor is IUniversalRewardsDistributor {
         }
     }
 
-    /// @notice Accepts the current pending merkle tree's root.
+    /// @notice Accepts the current pending merkle root.
     /// @dev This function can only be called after the timelock has expired.
     /// @dev Anyone can call this function.
     function acceptRoot() external {
@@ -134,7 +134,7 @@ contract UniversalRewardsDistributor is IUniversalRewardsDistributor {
     }
 
     /// @notice Forces update the root of a given distribution.
-    /// @param newRoot The new merkle tree's root.
+    /// @param newRoot The new merkle root.
     /// @param newIpfsHash The optional ipfs hash containing metadata about the root (e.g. the merkle tree itself).
     /// @dev This function can only be called by the owner of the distribution.
     /// @dev Set to bytes32(0) to remove the root.

--- a/src/UrdFactory.sol
+++ b/src/UrdFactory.sol
@@ -19,7 +19,7 @@ contract UrdFactory {
     /// @notice Creates a new URD contract using CREATE2 opcode.
     /// @param initialOwner The initial owner of the URD.
     /// @param initialTimelock The initial timelock of the URD.
-    /// @param initialRoot The initial merkle tree's root of the URD.
+    /// @param initialRoot The initial merkle root of the URD.
     /// @param initialIpfsHash The optional ipfs hash containing metadata about the root (e.g. the merkle tree itself).
     /// @param salt The salt used for CREATE2 opcode.
     /// @return urd The address of the newly created URD.

--- a/src/interfaces/IUniversalRewardsDistributor.sol
+++ b/src/interfaces/IUniversalRewardsDistributor.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.7.4;
 
 /// @notice The pending root struct for a merkle tree distribution during the timelock.
 struct PendingRoot {
-    /// @dev The block timestamp of the pending root submission.
+    /// @dev The timestamp of the block in which the pending root was submitted.
     uint256 submittedAt;
     /// @dev The submitted pending root.
     bytes32 root;
@@ -31,7 +31,7 @@ interface IUniversalRewardsDistributor {
     function revokeRoot() external;
     function setOwner(address newOwner) external;
 
-    function proposeRoot(bytes32 newRoot, bytes32 ipfsHash) external;
+    function submitRoot(bytes32 newRoot, bytes32 ipfsHash) external;
 
     function claim(address account, address reward, uint256 claimable, bytes32[] memory proof)
         external

--- a/src/libraries/EventsLib.sol
+++ b/src/libraries/EventsLib.sol
@@ -6,18 +6,18 @@ pragma solidity ^0.8.0;
 /// @custom:contact security@morpho.org
 /// @notice Library exposing events.
 library EventsLib {
-    /// @notice Emitted when the merkle tree's root is set.
-    /// @param newRoot The new merkle tree's root.
+    /// @notice Emitted when the merkle root is set.
+    /// @param newRoot The new merkle root.
     /// @param newIpfsHash The optional ipfs hash containing metadata about the root (e.g. the merkle tree itself).
     event RootSet(bytes32 indexed newRoot, bytes32 indexed newIpfsHash);
 
-    /// @notice Emitted when a new merkle tree's root is proposed.
-    /// @param newRoot The new merkle tree's root.
+    /// @notice Emitted when a new merkle root is proposed.
+    /// @param newRoot The new merkle root.
     /// @param newIpfsHash The optional ipfs hash containing metadata about the root (e.g. the merkle tree itself).
     event RootProposed(bytes32 indexed newRoot, bytes32 indexed newIpfsHash);
 
     /// @notice Emitted when a merkle tree distribution timelock is set.
-    /// @param timelock The new merkle tree's timelock.
+    /// @param timelock The new merkle timelock.
     event TimelockSet(uint256 timelock);
 
     /// @notice Emitted when a merkle tree updater is added or removed.
@@ -25,7 +25,7 @@ library EventsLib {
     /// @param active The merkle tree updater's active state.
     event RootUpdaterSet(address indexed rootUpdater, bool active);
 
-    /// @notice Emitted when a merkle tree's pending root is revoked.
+    /// @notice Emitted when a merkle pending root is revoked.
     event RootRevoked();
 
     /// @notice Emitted when rewards are claimed.
@@ -43,8 +43,8 @@ library EventsLib {
     /// @param caller The address of the caller.
     /// @param owner The address of the URD owner.
     /// @param timelock The URD timelock.
-    /// @param root The URD merkle tree's root.
-    /// @param ipfsHash The URD merkle tree's ipfs hash.
+    /// @param root The URD's initial merkle root.
+    /// @param ipfsHash The URD's initial ipfs hash.
     /// @param salt The salt used for CREATE2 opcode.
     event UrdCreated(
         address indexed urd,

--- a/test/UniversalRewardsDistributorTest.sol
+++ b/test/UniversalRewardsDistributorTest.sol
@@ -117,11 +117,11 @@ contract UniversalRewardsDistributorTest is Test {
         );
     }
 
-    function testProposeRootWithoutTimelockAsOwner() public {
+    function testSubmitRootWithoutTimelockAsOwner() public {
         vm.prank(owner);
         vm.expectEmit(address(distributionWithoutTimeLock));
         emit EventsLib.RootSet(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
-        distributionWithoutTimeLock.proposeRoot(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
+        distributionWithoutTimeLock.submitRoot(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
 
         assertEq(distributionWithoutTimeLock.root(), DEFAULT_ROOT);
         assertEq(distributionWithoutTimeLock.ipfsHash(), DEFAULT_IPFS_HASH);
@@ -131,11 +131,11 @@ contract UniversalRewardsDistributorTest is Test {
         assertEq(pendingRoot.ipfsHash, bytes32(0));
     }
 
-    function testProposeRootWithoutTimelockAsUpdater() public {
+    function testSubmitRootWithoutTimelockAsUpdater() public {
         vm.prank(updater);
         vm.expectEmit(address(distributionWithoutTimeLock));
         emit EventsLib.RootSet(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
-        distributionWithoutTimeLock.proposeRoot(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
+        distributionWithoutTimeLock.submitRoot(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
 
         assertEq(distributionWithoutTimeLock.root(), DEFAULT_ROOT);
         assertEq(distributionWithoutTimeLock.ipfsHash(), DEFAULT_IPFS_HASH);
@@ -145,19 +145,19 @@ contract UniversalRewardsDistributorTest is Test {
         assertEq(pendingRoot.ipfsHash, bytes32(0));
     }
 
-    function testProposeRootWithoutTimelockAsRandomCallerShouldRevert(address randomCaller) public {
+    function testSubmitRootWithoutTimelockAsRandomCallerShouldRevert(address randomCaller) public {
         vm.assume(!distributionWithoutTimeLock.isUpdater(randomCaller) && randomCaller != owner);
 
         vm.prank(randomCaller);
         vm.expectRevert(bytes(ErrorsLib.CALLER_NOT_OWNER_OR_UPDATER));
-        distributionWithoutTimeLock.proposeRoot(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
+        distributionWithoutTimeLock.submitRoot(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
     }
 
-    function testProposeRootWithTimelockAsOwner() public {
+    function testSubmitRootWithTimelockAsOwner() public {
         vm.prank(owner);
         vm.expectEmit(address(distributionWithTimeLock));
         emit EventsLib.RootProposed(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
-        distributionWithTimeLock.proposeRoot(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
+        distributionWithTimeLock.submitRoot(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
 
         assert(distributionWithTimeLock.root() != DEFAULT_ROOT);
 
@@ -167,11 +167,11 @@ contract UniversalRewardsDistributorTest is Test {
         assertEq(pendingRoot.submittedAt, block.timestamp);
     }
 
-    function testProposeRootWithTimelockAsUpdater() public {
+    function testSubmitRootWithTimelockAsUpdater() public {
         vm.prank(updater);
         vm.expectEmit(address(distributionWithTimeLock));
         emit EventsLib.RootProposed(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
-        distributionWithTimeLock.proposeRoot(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
+        distributionWithTimeLock.submitRoot(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
 
         assert(distributionWithTimeLock.root() != DEFAULT_ROOT);
 
@@ -181,17 +181,17 @@ contract UniversalRewardsDistributorTest is Test {
         assertEq(pendingRoot.submittedAt, block.timestamp);
     }
 
-    function testProposeRootWithTimelockAsRandomCallerShouldRevert(address randomCaller) public {
+    function testSubmitRootWithTimelockAsRandomCallerShouldRevert(address randomCaller) public {
         vm.assume(!distributionWithTimeLock.isUpdater(randomCaller) && randomCaller != owner);
 
         vm.prank(randomCaller);
         vm.expectRevert(bytes(ErrorsLib.CALLER_NOT_OWNER_OR_UPDATER));
-        distributionWithTimeLock.proposeRoot(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
+        distributionWithTimeLock.submitRoot(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
     }
 
     function testAcceptRootShouldUpdateMainRoot(address randomCaller) public {
         vm.prank(updater);
-        distributionWithTimeLock.proposeRoot(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
+        distributionWithTimeLock.submitRoot(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
 
         assert(distributionWithTimeLock.root() != DEFAULT_ROOT);
         vm.warp(block.timestamp + 1 days);
@@ -213,7 +213,7 @@ contract UniversalRewardsDistributorTest is Test {
         timeElapsed = bound(timeElapsed, 0, distributionWithTimeLock.timelock() - 1);
 
         vm.prank(updater);
-        distributionWithTimeLock.proposeRoot(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
+        distributionWithTimeLock.submitRoot(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
 
         assert(distributionWithTimeLock.root() != DEFAULT_ROOT);
 
@@ -258,7 +258,7 @@ contract UniversalRewardsDistributorTest is Test {
         vm.assume(newRoot != DEFAULT_ROOT && randomCaller != owner);
 
         vm.startPrank(owner);
-        distributionWithTimeLock.proposeRoot(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
+        distributionWithTimeLock.submitRoot(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
 
         assertEq(_getPendingRoot(distributionWithTimeLock).root, DEFAULT_ROOT);
 
@@ -291,7 +291,7 @@ contract UniversalRewardsDistributorTest is Test {
         beforeEndOfTimelock = bound(beforeEndOfTimelock, 0, newTimelock - timeElapsed - 1);
         afterEndOfTimelock = bound(afterEndOfTimelock, newTimelock - beforeEndOfTimelock + 1, type(uint128).max);
         vm.prank(owner);
-        distributionWithTimeLock.proposeRoot(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
+        distributionWithTimeLock.submitRoot(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
 
         vm.warp(block.timestamp + timeElapsed);
 
@@ -328,7 +328,7 @@ contract UniversalRewardsDistributorTest is Test {
         timeElapsed = bound(timeElapsed, 0, DEFAULT_TIMELOCK - 1);
 
         vm.prank(owner);
-        distributionWithTimeLock.proposeRoot(pendingRoot, DEFAULT_IPFS_HASH);
+        distributionWithTimeLock.submitRoot(pendingRoot, DEFAULT_IPFS_HASH);
 
         vm.warp(block.timestamp + timeElapsed);
 
@@ -339,7 +339,7 @@ contract UniversalRewardsDistributorTest is Test {
 
     function testSetTimelockShouldWorkIfPendingRootIsUpdatableButNotYetUpdated() public {
         vm.prank(owner);
-        distributionWithTimeLock.proposeRoot(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
+        distributionWithTimeLock.submitRoot(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
 
         vm.warp(block.timestamp + DEFAULT_TIMELOCK);
 
@@ -370,7 +370,7 @@ contract UniversalRewardsDistributorTest is Test {
 
     function testRevokeRootShouldRevokeWhenCalledWithOwner() public {
         vm.prank(owner);
-        distributionWithTimeLock.proposeRoot(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
+        distributionWithTimeLock.submitRoot(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
 
         vm.prank(owner);
         vm.expectEmit(address(distributionWithTimeLock));
@@ -386,7 +386,7 @@ contract UniversalRewardsDistributorTest is Test {
         vm.assume(proposedRoot != bytes32(0) && caller != owner);
 
         vm.prank(owner);
-        distributionWithTimeLock.proposeRoot(proposedRoot, DEFAULT_IPFS_HASH);
+        distributionWithTimeLock.submitRoot(proposedRoot, DEFAULT_IPFS_HASH);
 
         vm.prank(caller);
         vm.expectRevert(bytes(ErrorsLib.CALLER_NOT_OWNER));
@@ -425,7 +425,7 @@ contract UniversalRewardsDistributorTest is Test {
         (bytes32[] memory data, bytes32 root) = _setupRewards(claimable, boundedSize);
 
         vm.prank(owner);
-        distributionWithoutTimeLock.proposeRoot(root, DEFAULT_IPFS_HASH);
+        distributionWithoutTimeLock.submitRoot(root, DEFAULT_IPFS_HASH);
 
         assertEq(distributionWithoutTimeLock.root(), root);
 
@@ -438,7 +438,7 @@ contract UniversalRewardsDistributorTest is Test {
         (bytes32[] memory data, bytes32 root) = _setupRewards(claimable, 2);
 
         vm.prank(owner);
-        distributionWithoutTimeLock.proposeRoot(root, DEFAULT_IPFS_HASH);
+        distributionWithoutTimeLock.submitRoot(root, DEFAULT_IPFS_HASH);
 
         assertEq(distributionWithoutTimeLock.root(), root);
         bytes32[] memory proof1 = merkle.getProof(data, 0);
@@ -457,7 +457,7 @@ contract UniversalRewardsDistributorTest is Test {
         (bytes32[] memory data, bytes32 root) = _setupRewards(claimable, 2);
 
         vm.prank(owner);
-        distributionWithoutTimeLock.proposeRoot(root, DEFAULT_IPFS_HASH);
+        distributionWithoutTimeLock.submitRoot(root, DEFAULT_IPFS_HASH);
 
         assertEq(distributionWithoutTimeLock.root(), root);
         bytes32[] memory proof1 = merkle.getProof(data, 0);
@@ -471,7 +471,7 @@ contract UniversalRewardsDistributorTest is Test {
         (bytes32[] memory data2, bytes32 root2) = _setupRewards(claimable * 2, 2);
 
         vm.prank(owner);
-        distributionWithoutTimeLock.proposeRoot(root2, DEFAULT_IPFS_HASH);
+        distributionWithoutTimeLock.submitRoot(root2, DEFAULT_IPFS_HASH);
 
         assertEq(distributionWithoutTimeLock.root(), root2);
         bytes32[] memory proof2 = merkle.getProof(data2, 0);
@@ -501,7 +501,7 @@ contract UniversalRewardsDistributorTest is Test {
 
         vm.assume(root != invalidRoot);
         vm.prank(owner);
-        distributionWithoutTimeLock.proposeRoot(invalidRoot, DEFAULT_IPFS_HASH);
+        distributionWithoutTimeLock.submitRoot(invalidRoot, DEFAULT_IPFS_HASH);
 
         bytes32[] memory proof1 = merkle.getProof(data, 0);
 


### PR DESCRIPTION
- Renames `proposeRoot` to `submitRoot` to stick to `submittedAt` wording
- "merkle tree root/merkle tree's root" => "merkle root"