### PR TITLE
Fix pending root event emission

### DIFF
--- a/src/UniversalRewardsDistributor.sol
+++ b/src/UniversalRewardsDistributor.sol
@@ -82,7 +82,8 @@ contract UniversalRewardsDistributor is IUniversalRewardsDistributor {
             _setRoot(newRoot, newIpfsHash);
         } else {
             pendingRoot = PendingRoot(block.timestamp, newRoot, newIpfsHash);
-            emit EventsLib.RootProposed(newRoot, newIpfsHash);
+
+            emit EventsLib.PendingRootSet(newRoot, newIpfsHash);
         }
     }
 
@@ -167,7 +168,7 @@ contract UniversalRewardsDistributor is IUniversalRewardsDistributor {
 
         delete pendingRoot;
 
-        emit EventsLib.RootRevoked();
+        emit EventsLib.PendingRootSet(bytes32(0), bytes32(0));
     }
 
     /// @notice Sets the `owner` of the distribution to `newOwner`.
@@ -184,9 +185,11 @@ contract UniversalRewardsDistributor is IUniversalRewardsDistributor {
         root = newRoot;
         ipfsHash = newIpfsHash;
 
+        emit EventsLib.RootSet(newRoot, newIpfsHash);
+
         delete pendingRoot;
 
-        emit EventsLib.RootSet(newRoot, newIpfsHash);
+        emit EventsLib.PendingRootSet(bytes32(0), bytes32(0));
     }
 
     /// @dev Sets the `owner` of the distribution to `newOwner`.

--- a/src/libraries/EventsLib.sol
+++ b/src/libraries/EventsLib.sol
@@ -14,7 +14,7 @@ library EventsLib {
     /// @notice Emitted when a new Merkle root is proposed.
     /// @param newRoot The new Merkle root.
     /// @param newIpfsHash The optional ipfs hash containing metadata about the root (e.g. the Merkle tree itself).
-    event RootProposed(bytes32 indexed newRoot, bytes32 indexed newIpfsHash);
+    event PendingRootSet(bytes32 indexed newRoot, bytes32 indexed newIpfsHash);
 
     /// @notice Emitted when a Merkle tree distribution timelock is set.
     /// @param timelock The new Merkle timelock.
@@ -24,9 +24,6 @@ library EventsLib {
     /// @param rootUpdater The Merkle tree updater.
     /// @param active The Merkle tree updater's active state.
     event RootUpdaterSet(address indexed rootUpdater, bool active);
-
-    /// @notice Emitted when a Merkle pending root is revoked.
-    event RootRevoked();
 
     /// @notice Emitted when rewards are claimed.
     /// @param account The address for which rewards are claimd rewards for.

--- a/test/UniversalRewardsDistributorTest.sol
+++ b/test/UniversalRewardsDistributorTest.sol
@@ -156,7 +156,7 @@ contract UniversalRewardsDistributorTest is Test {
     function testSubmitRootWithTimelockAsOwner() public {
         vm.prank(owner);
         vm.expectEmit(address(distributionWithTimeLock));
-        emit EventsLib.RootProposed(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
+        emit EventsLib.PendingRootSet(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
         distributionWithTimeLock.submitRoot(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
 
         assert(distributionWithTimeLock.root() != DEFAULT_ROOT);
@@ -170,7 +170,7 @@ contract UniversalRewardsDistributorTest is Test {
     function testSubmitRootWithTimelockAsUpdater() public {
         vm.prank(updater);
         vm.expectEmit(address(distributionWithTimeLock));
-        emit EventsLib.RootProposed(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
+        emit EventsLib.PendingRootSet(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
         distributionWithTimeLock.submitRoot(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
 
         assert(distributionWithTimeLock.root() != DEFAULT_ROOT);
@@ -374,7 +374,7 @@ contract UniversalRewardsDistributorTest is Test {
 
         vm.prank(owner);
         vm.expectEmit(address(distributionWithTimeLock));
-        emit EventsLib.RootRevoked();
+        emit EventsLib.PendingRootSet(bytes32(0), bytes32(0));
         distributionWithTimeLock.revokeRoot();
 
         PendingRoot memory pendingRoot = _getPendingRoot(distributionWithTimeLock);


### PR DESCRIPTION
Fixes: 
- #74 

Also unifies two events that were about the pending root update. Now the pending root value are always equal to the values in the last `PendingRootSet` event