### PR TITLE
Streamline `submitRoot` and `setRoot`

### DIFF
--- a/src/UniversalRewardsDistributor.sol
+++ b/src/UniversalRewardsDistributor.sol
@@ -78,16 +78,11 @@ contract UniversalRewardsDistributor is IUniversalRewardsDistributorStaticTyping
     /// @param newIpfsHash The optional ipfs hash containing metadata about the root (e.g. the merkle tree itself).
     /// @dev Warning: The `newIpfsHash` might not correspond to the `newRoot`.
     function submitRoot(bytes32 newRoot, bytes32 newIpfsHash) external onlyUpdaterRole {
-        require(newRoot != root || newIpfsHash != ipfsHash, ErrorsLib.ALREADY_SET);
+        require(newRoot != pendingRoot.root || newIpfsHash != pendingRoot.ipfsHash, ErrorsLib.ALREADY_PENDING);
 
-        if (timelock == 0) {
-            _setRoot(newRoot, newIpfsHash);
-        } else {
-            require(newRoot != pendingRoot.root || newIpfsHash != pendingRoot.ipfsHash, ErrorsLib.ALREADY_PENDING);
+        pendingRoot = PendingRoot(block.timestamp + timelock, newRoot, newIpfsHash);
 
-            pendingRoot = PendingRoot(block.timestamp + timelock, newRoot, newIpfsHash);
-            emit EventsLib.RootProposed(newRoot, newIpfsHash);
-        }
+        emit EventsLib.RootProposed(newRoot, newIpfsHash);
     }
 
     /// @notice Accepts and sets the current pending merkle root.
@@ -133,10 +128,11 @@ contract UniversalRewardsDistributor is IUniversalRewardsDistributorStaticTyping
     /// @notice Forces update the root of a given distribution (bypassing the timelock).
     /// @param newRoot The new merkle root.
     /// @param newIpfsHash The optional ipfs hash containing metadata about the root (e.g. the merkle tree itself).
-    /// @dev This function can only be called by the owner of the distribution.
+    /// @dev This function can only be called by the owner of the distribution or by updaters if there are no timelock.
     /// @dev Set to bytes32(0) to remove the root.
-    function setRoot(bytes32 newRoot, bytes32 newIpfsHash) external onlyOwner {
+    function setRoot(bytes32 newRoot, bytes32 newIpfsHash) external onlyUpdaterRole {
         require(newRoot != root || newIpfsHash != ipfsHash, ErrorsLib.ALREADY_SET);
+        require(timelock == 0 || msg.sender == owner, ErrorsLib.UNAUTHORIZED_ROOT_CHANGE);
 
         _setRoot(newRoot, newIpfsHash);
     }

--- a/src/UniversalRewardsDistributor.sol
+++ b/src/UniversalRewardsDistributor.sol
@@ -128,7 +128,7 @@ contract UniversalRewardsDistributor is IUniversalRewardsDistributorStaticTyping
     /// @notice Forces update the root of a given distribution (bypassing the timelock).
     /// @param newRoot The new merkle root.
     /// @param newIpfsHash The optional ipfs hash containing metadata about the root (e.g. the merkle tree itself).
-    /// @dev This function can only be called by the owner of the distribution or by updaters if there are no timelock.
+    /// @dev This function can only be called by the owner of the distribution or by updaters if there is no timelock.
     /// @dev Set to bytes32(0) to remove the root.
     function setRoot(bytes32 newRoot, bytes32 newIpfsHash) external onlyUpdaterRole {
         require(newRoot != root || newIpfsHash != ipfsHash, ErrorsLib.ALREADY_SET);

--- a/src/libraries/ErrorsLib.sol
+++ b/src/libraries/ErrorsLib.sol
@@ -12,6 +12,9 @@ library ErrorsLib {
     /// @notice Thrown when the caller is not the owner.
     string internal constant NOT_OWNER = "caller is not the owner";
 
+    /// @notice Thrown when the caller trying to change the root under timelock is not the owner.
+    string internal constant UNAUTHORIZED_ROOT_CHANGE = "unauthorized to change the root";
+
     /// @notice Thrown when there is not pending root.
     string internal constant NO_PENDING_ROOT = "no pending root";
 

--- a/test/UniversalRewardsDistributorTest.sol
+++ b/test/UniversalRewardsDistributorTest.sol
@@ -301,7 +301,6 @@ contract UniversalRewardsDistributorTest is Test {
         assertEq(pendingRoot.ipfsHash, bytes32(0));
     }
 
-
     function testSetRootShouldRemovePendingRoot(bytes32 newRoot, address randomCaller) public {
         vm.assume(newRoot != DEFAULT_ROOT && randomCaller != owner);
 

--- a/test/UniversalRewardsDistributorTest.sol
+++ b/test/UniversalRewardsDistributorTest.sol
@@ -125,34 +125,6 @@ contract UniversalRewardsDistributorTest is Test {
         );
     }
 
-    function testSubmitRootWithoutTimelockAsOwner() public {
-        vm.prank(owner);
-        vm.expectEmit(address(distributionWithoutTimeLock));
-        emit EventsLib.RootSet(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
-        distributionWithoutTimeLock.submitRoot(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
-
-        assertEq(distributionWithoutTimeLock.root(), DEFAULT_ROOT);
-        assertEq(distributionWithoutTimeLock.ipfsHash(), DEFAULT_IPFS_HASH);
-        PendingRoot memory pendingRoot = distributionWithoutTimeLock.pendingRoot();
-        assertEq(pendingRoot.root, bytes32(0));
-        assertEq(pendingRoot.validAt, 0);
-        assertEq(pendingRoot.ipfsHash, bytes32(0));
-    }
-
-    function testSubmitRootWithoutTimelockAsUpdater() public {
-        vm.prank(updater);
-        vm.expectEmit(address(distributionWithoutTimeLock));
-        emit EventsLib.RootSet(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
-        distributionWithoutTimeLock.submitRoot(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
-
-        assertEq(distributionWithoutTimeLock.root(), DEFAULT_ROOT);
-        assertEq(distributionWithoutTimeLock.ipfsHash(), DEFAULT_IPFS_HASH);
-        PendingRoot memory pendingRoot = distributionWithoutTimeLock.pendingRoot();
-        assertEq(pendingRoot.root, bytes32(0));
-        assertEq(pendingRoot.validAt, 0);
-        assertEq(pendingRoot.ipfsHash, bytes32(0));
-    }
-
     function testSubmitRootWithoutTimelockAsRandomCallerShouldRevert(address randomCaller) public {
         vm.assume(!distributionWithoutTimeLock.isUpdater(randomCaller) && randomCaller != owner);
 
@@ -170,29 +142,6 @@ contract UniversalRewardsDistributorTest is Test {
         vm.expectRevert(bytes(ErrorsLib.ALREADY_PENDING));
         distributionWithTimeLock.submitRoot(newRoot, newIpfsHash);
 
-        vm.stopPrank();
-    }
-
-    function testSubmitRootWithCurrentRootAndNoTimelockShouldRevert(bytes32 newRoot, bytes32 newIpfsHash) public {
-        vm.assume(newRoot != distributionWithTimeLock.root() && newIpfsHash != distributionWithTimeLock.ipfsHash());
-
-        vm.startPrank(owner);
-        distributionWithoutTimeLock.submitRoot(newRoot, newIpfsHash);
-
-        vm.expectRevert(bytes(ErrorsLib.ALREADY_SET));
-        distributionWithoutTimeLock.submitRoot(newRoot, newIpfsHash);
-
-        vm.stopPrank();
-    }
-
-    function testSubmitRootWithCurrentRootShouldRevert(bytes32 newRoot, bytes32 newIpfsHash) public {
-        vm.assume(newRoot != distributionWithTimeLock.root() && newIpfsHash != distributionWithTimeLock.ipfsHash());
-
-        vm.startPrank(owner);
-        distributionWithTimeLock.setRoot(newRoot, newIpfsHash);
-
-        vm.expectRevert(bytes(ErrorsLib.ALREADY_SET));
-        distributionWithTimeLock.submitRoot(newRoot, newIpfsHash);
         vm.stopPrank();
     }
 
@@ -294,12 +243,32 @@ contract UniversalRewardsDistributorTest is Test {
         distributionWithTimeLock.acceptRoot();
     }
 
-    function testSetRootShouldRevertIfNotOwner(bytes32 newRoot, address randomCaller) public {
+    function testSetRootWithoutTimelockAsRandomCallerShouldRevert(address randomCaller) public {
+        vm.assume(!distributionWithoutTimeLock.isUpdater(randomCaller) && randomCaller != owner);
+
+        vm.prank(randomCaller);
+        vm.expectRevert(bytes(ErrorsLib.NOT_UPDATER_ROLE));
+        distributionWithoutTimeLock.setRoot(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
+    }
+
+    function testSetRootWithTimelockShouldRevertIfNotOwner(bytes32 newRoot, address randomCaller) public {
         vm.assume(randomCaller != owner);
 
         vm.prank(randomCaller);
-        vm.expectRevert(bytes(ErrorsLib.NOT_OWNER));
-        distributionWithoutTimeLock.setRoot(newRoot, DEFAULT_IPFS_HASH);
+        vm.expectRevert();
+        distributionWithTimeLock.setRoot(newRoot, DEFAULT_IPFS_HASH);
+    }
+
+    function testSetRootWithPreviousRootShouldRevert(bytes32 newRoot, bytes32 newIpfsHash) public {
+        vm.assume(newRoot != distributionWithTimeLock.root() && newIpfsHash != distributionWithTimeLock.ipfsHash());
+
+        vm.startPrank(owner);
+        distributionWithTimeLock.setRoot(newRoot, newIpfsHash);
+
+        vm.expectRevert(bytes(ErrorsLib.ALREADY_SET));
+        distributionWithTimeLock.setRoot(newRoot, newIpfsHash);
+
+        vm.stopPrank();
     }
 
     function testSetRootShouldUpdateTheCurrentRoot(bytes32 newRoot, bytes32 newIpfsHash) public {
@@ -317,6 +286,21 @@ contract UniversalRewardsDistributorTest is Test {
         assertEq(pendingRoot.ipfsHash, bytes32(0));
         assertEq(pendingRoot.validAt, 0);
     }
+
+    function testSetRootWithoutTimelockAsUpdater() public {
+        vm.prank(updater);
+        vm.expectEmit(address(distributionWithoutTimeLock));
+        emit EventsLib.RootSet(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
+        distributionWithoutTimeLock.setRoot(DEFAULT_ROOT, DEFAULT_IPFS_HASH);
+
+        assertEq(distributionWithoutTimeLock.root(), DEFAULT_ROOT);
+        assertEq(distributionWithoutTimeLock.ipfsHash(), DEFAULT_IPFS_HASH);
+        PendingRoot memory pendingRoot = distributionWithoutTimeLock.pendingRoot();
+        assertEq(pendingRoot.root, bytes32(0));
+        assertEq(pendingRoot.validAt, 0);
+        assertEq(pendingRoot.ipfsHash, bytes32(0));
+    }
+
 
     function testSetRootShouldRemovePendingRoot(bytes32 newRoot, address randomCaller) public {
         vm.assume(newRoot != DEFAULT_ROOT && randomCaller != owner);
@@ -525,7 +509,7 @@ contract UniversalRewardsDistributorTest is Test {
         (bytes32[] memory data, bytes32 root) = _setupRewards(claimable, boundedSize);
 
         vm.prank(owner);
-        distributionWithoutTimeLock.submitRoot(root, DEFAULT_IPFS_HASH);
+        distributionWithoutTimeLock.setRoot(root, DEFAULT_IPFS_HASH);
 
         assertEq(distributionWithoutTimeLock.root(), root);
 
@@ -538,7 +522,7 @@ contract UniversalRewardsDistributorTest is Test {
         (bytes32[] memory data, bytes32 root) = _setupRewards(claimable, 2);
 
         vm.prank(owner);
-        distributionWithoutTimeLock.submitRoot(root, DEFAULT_IPFS_HASH);
+        distributionWithoutTimeLock.setRoot(root, DEFAULT_IPFS_HASH);
 
         assertEq(distributionWithoutTimeLock.root(), root);
         bytes32[] memory proof1 = merkle.getProof(data, 0);
@@ -551,14 +535,14 @@ contract UniversalRewardsDistributorTest is Test {
         distributionWithoutTimeLock.claim(vm.addr(1), address(token1), claimable, proof1);
     }
 
-    function testClaimShouldReturnsTheAmountClaimed(uint256 claimable) public {
+    function testClaimShouldReturnTheAmountClaimed(uint256 claimable) public {
         vm.assume(claimable > 0);
         claimable = bound(claimable, 1 ether, 1000 ether);
 
         (bytes32[] memory data, bytes32 root) = _setupRewards(claimable, 2);
 
         vm.prank(owner);
-        distributionWithoutTimeLock.submitRoot(root, DEFAULT_IPFS_HASH);
+        distributionWithoutTimeLock.setRoot(root, DEFAULT_IPFS_HASH);
 
         assertEq(distributionWithoutTimeLock.root(), root);
         bytes32[] memory proof1 = merkle.getProof(data, 0);
@@ -572,7 +556,7 @@ contract UniversalRewardsDistributorTest is Test {
         (bytes32[] memory data2, bytes32 root2) = _setupRewards(claimable * 2, 2);
 
         vm.prank(owner);
-        distributionWithoutTimeLock.submitRoot(root2, DEFAULT_IPFS_HASH);
+        distributionWithoutTimeLock.setRoot(root2, DEFAULT_IPFS_HASH);
 
         assertEq(distributionWithoutTimeLock.root(), root2);
         bytes32[] memory proof2 = merkle.getProof(data2, 0);
@@ -602,7 +586,7 @@ contract UniversalRewardsDistributorTest is Test {
 
         vm.assume(root != invalidRoot);
         vm.prank(owner);
-        distributionWithoutTimeLock.submitRoot(invalidRoot, DEFAULT_IPFS_HASH);
+        distributionWithoutTimeLock.setRoot(invalidRoot, DEFAULT_IPFS_HASH);
 
         bytes32[] memory proof1 = merkle.getProof(data, 0);
 


### PR DESCRIPTION
Refactor `submitRoot` and `setRoot` so that they only do one thing each: respectively updating the pending root & the current root. 

The main goal of this PR is to not rely on the storage variable `timelock` to decide on what storage variable to update in the `submitRoot` function. Relying on `timelock` is not wanted because that value can change between the moment at which the tx is sent, and the moment it is executed. This means that a bot observing the chain and the `timelock` variable could think that a `submitRoot` transaction would update either the pending root or the current root, but it would update the other one in the end.

It is always possible to submit the pending root, even if there are no timelock. This is a deliberate choice, because it does not change the capabilities of the updaters anyway. It can be discussed and easily changed if we want to prevent this